### PR TITLE
Fix jupyter paths

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -203,7 +203,10 @@
               ln -s ${jupyterlab}/bin/$filename $out/bin/$filename
               wrapProgram $out/bin/$filename \
                 --set JUPYTERLAB_DIR ${jupyterlab}/share/jupyter/lab \
-                --set JUPYTER_PATH ${kernelsString requestedKernels}
+                --set JUPYTER_PATH ${kernelsString requestedKernels} \
+                --set JUPYTER_CONFIG_DIR "/doesNotExist1" \
+                --set JUPYTER_DATA_DIR "/doesNotExist2" \
+                --set JUPYTER_RUNTIME_DIR '$HOME/.local/share/jupyter/runtime'
             done
           '';
 

--- a/overrides.nix
+++ b/overrides.nix
@@ -16,10 +16,13 @@ in
   // {
     jupyter-core = prev.jupyter-core.overridePythonAttrs (old: {
       postPatch = ''
+        # remove system paths from jupyter paths
         sed -i \
           -e '/paths.extend(SYSTEM_JUPYTER_PATH)/d' \
           -e '/paths.extend(SYSTEM_CONFIG_PATH)/d' \
             ./jupyter_core/paths.py
+        sed -i -E 's/(ENV_JUPYTER_PATH = )(\[.*\])/\1[]/g' ./jupyter_core/paths.py
+        sed -i -E 's/(ENV_CONFIG_PATH = )(\[.*\])/\1[]/g' ./jupyter_core/paths.py
       '';
     });
   }

--- a/overrides.nix
+++ b/overrides.nix
@@ -13,3 +13,13 @@ in
   // addNativeBuildInputs "jupyter-server" [final.hatchling]
   // addNativeBuildInputs "jupyterlab-server" [final.hatchling]
   // addNativeBuildInputs "ipykernel" [final.hatchling]
+  // {
+    jupyter-core = prev.jupyter-core.overridePythonAttrs (old: {
+      postPatch = ''
+        sed -i \
+          -e '/paths.extend(SYSTEM_JUPYTER_PATH)/d' \
+          -e '/paths.extend(SYSTEM_CONFIG_PATH)/d' \
+            ./jupyter_core/paths.py
+      '';
+    });
+  }


### PR DESCRIPTION
Note: This currently introduces breaking changes into the code by by explicitly setting the jupyter paths to directories that do not exist. However it does remove many of the unwanted system and user paths from the jupyter paths. The paths that jupyter sees are now:

```shell
config:
    /doesNotExist1
data:
    /nix/store/mnpg1gshfxys72yi26zgvvdqpypws578-example_ansible-jupyter-kernel
    /nix/store/dgh0p09awjwd7gzi17pf6mwxvlxic16h-example_ansible_stable-jupyter-kernel
    /nix/store/4k4vqxjny5nnfpym0r3ca8xizwphhxmv-example_bash-jupyter-kernel
    /nix/store/b030rlqd1clkas2di0rmppk5rhiwf3kx-example_c-jupyter-kernel
    /nix/store/k4rmbp7vv4rj01davjkzkwcnr83n5cak-example_ipython-jupyter-kernel
    /nix/store/cwiy2ml5qlyfyjzc35dqzln9d061k0dy-example_nix-jupyter-kernel
    /nix/store/mzf7h6p365wl1y9b515cqlxq98188cfp-example_rust-jupyter-kernel
    /doesNotExist2
runtime:
    $HOME/.local/share/jupyter/runtime
```

whereas before it was:

```shell
config:
    /home/bakerdn/.jupyter
    /nix/store/kx6q1gz2mm6maasahhkq3p4srk2hhgf6-python3-3.9.13-env/etc/jupyter
    /usr/local/etc/jupyter
    /etc/jupyter
data:
    /nix/store/mnpg1gshfxys72yi26zgvvdqpypws578-example_ansible-jupyter-kernel
    /nix/store/dgh0p09awjwd7gzi17pf6mwxvlxic16h-example_ansible_stable-jupyter-kernel
    /nix/store/4k4vqxjny5nnfpym0r3ca8xizwphhxmv-example_bash-jupyter-kernel
    /nix/store/b030rlqd1clkas2di0rmppk5rhiwf3kx-example_c-jupyter-kernel
    /nix/store/k4rmbp7vv4rj01davjkzkwcnr83n5cak-example_ipython-jupyter-kernel
    /nix/store/cwiy2ml5qlyfyjzc35dqzln9d061k0dy-example_nix-jupyter-kernel
    /nix/store/mzf7h6p365wl1y9b515cqlxq98188cfp-example_rust-jupyter-kernel
    /home/bakerdn/.local/share/jupyter
    /nix/store/kx6q1gz2mm6maasahhkq3p4srk2hhgf6-python3-3.9.13-env/share/jupyter
    /usr/local/share/jupyter
    /usr/share/jupyter
runtime:
    /home/bakerdn/.local/share/jupyter/runtime
```

Further work needs to be done to resolve the desired config, data, and runtime paths.