### PR TITLE
Fix jupyter paths - runtime

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -203,7 +203,10 @@
               ln -s ${jupyterlab}/bin/$filename $out/bin/$filename
               wrapProgram $out/bin/$filename \
                 --set JUPYTERLAB_DIR ${jupyterlab}/share/jupyter/lab \
-                --set JUPYTER_PATH ${kernelsString requestedKernels}
+                --set JUPYTER_PATH ${kernelsString requestedKernels} \
+                --set JUPYTER_CONFIG_DIR "/doesNotExist1" \
+                --set JUPYTER_DATA_DIR "/doesNotExist2" \
+                --set JUPYTER_RUNTIME_DIR '$HOME/.local/share/jupyter/runtime'
             done
           '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -194,9 +194,9 @@
 
           kernelsString = lib.concatStringsSep ":";
 
-          # create directories for storing jupyter configs
+          # create directories for storing jupyter configs and runtime
           jupyterDir = pkgs.runCommand "jupyter-dir" {} ''
-            mkdir -p $out/config $out/data
+            mkdir -p $out/config $out/data $out/runtime
           '';
         in
           pkgs.runCommand "wrapper-${jupyterlab.name}"
@@ -212,7 +212,7 @@
                 --set JUPYTER_CONFIG_DIR "${jupyterDir}/config" \
                 --set JUPYTER_DATA_DIR "${jupyterDir}/data" \
                 --set IPYTHONDIR "/does-not-exists" \
-                --set JUPYTER_RUNTIME_DIR '$HOME/.local/share/jupyter/runtime'
+                --set JUPYTER_RUNTIME_DIR "${jupyterDir}/runtime"
             done
           '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -194,6 +194,7 @@
 
           kernelsString = lib.concatStringsSep ":";
 
+          # create directories for storing jupyter configs
           jupyterDir = pkgs.runCommand "jupyter-dir" {} ''
             mkdir -p $out/config $out/data
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,6 @@
           .override {
             postBuild = ''
               rm -rf $out/share/jupyter/kernels
-              #exit 123
             '';
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -194,9 +194,9 @@
 
           kernelsString = lib.concatStringsSep ":";
 
-          # create directories for storing jupyter configs and runtime
+          # create directories for storing jupyter configs
           jupyterDir = pkgs.runCommand "jupyter-dir" {} ''
-            mkdir -p $out/config $out/data $out/runtime
+            mkdir -p $out/config $out/data
           '';
         in
           pkgs.runCommand "wrapper-${jupyterlab.name}"
@@ -212,7 +212,7 @@
                 --set JUPYTER_CONFIG_DIR "${jupyterDir}/config" \
                 --set JUPYTER_DATA_DIR "${jupyterDir}/data" \
                 --set IPYTHONDIR "/does-not-exists" \
-                --set JUPYTER_RUNTIME_DIR "${jupyterDir}/runtime"
+                --set JUPYTER_RUNTIME_DIR '$HOME/.local/share/jupyter/runtime'
             done
           '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -211,8 +211,8 @@
                 --set JUPYTER_PATH ${kernelsString requestedKernels} \
                 --set JUPYTER_CONFIG_DIR "${jupyterDir}/config" \
                 --set JUPYTER_DATA_DIR "${jupyterDir}/data" \
-                --set IPYTHONDIR "/does-not-exists" \
-                --set JUPYTER_RUNTIME_DIR '$HOME/.local/share/jupyter/runtime'
+                --set IPYTHONDIR "/path-not-set" \
+                --set JUPYTER_RUNTIME_DIR "/path-not-set"
             done
           '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -69,11 +69,18 @@
           };
         };
 
-        jupyterlab = pkgs.poetry2nix.mkPoetryEnv {
-          python = pkgs.python3;
-          projectDir = self; # TODO: only include relevant files/folders
-          overrides = pkgs.poetry2nix.overrides.withDefaults (import ./overrides.nix);
-        };
+        jupyterlab =
+          (pkgs.poetry2nix.mkPoetryEnv {
+            python = pkgs.python3;
+            projectDir = self; # TODO: only include relevant files/folders
+            overrides = pkgs.poetry2nix.overrides.withDefaults (import ./overrides.nix);
+          })
+          .override {
+            postBuild = ''
+              rm -rf $out/share/jupyter/kernels
+              #exit 123
+            '';
+          };
 
         mkKernel = kernel: args: name: let
           # TODO: we should probably assert that the kernel is correctly shaped.

--- a/overrides.nix
+++ b/overrides.nix
@@ -29,8 +29,13 @@ in
           -e '/paths.extend(SYSTEM_JUPYTER_PATH)/d' \
           -e '/paths.extend(SYSTEM_CONFIG_PATH)/d' \
             ./jupyter_core/paths.py
+        # empty the ENV_JUPYTER_PATH and ENV_CONFIG_PATH lists
         sed -i -E 's/(ENV_JUPYTER_PATH = )(\[.*\])/\1[]/g' ./jupyter_core/paths.py
         sed -i -E 's/(ENV_CONFIG_PATH = )(\[.*\])/\1[]/g' ./jupyter_core/paths.py
+        # override the funtion that returns the jupyter runtime dir
+        sed -i \
+          -e "/def jupyter_runtime_dir():/!b;n;i\    return pjoin(get_home_dir(), '.local', 'share', 'jupyter', 'runtime')" \
+          ./jupyter_core/paths.py
       '';
     });
   }

--- a/overrides.nix
+++ b/overrides.nix
@@ -16,10 +16,13 @@ in
   // {
     jupyter-core = prev.jupyter-core.overridePythonAttrs (old: {
       postPatch = ''
+        # remove system paths from jupyter paths
         sed -i \
           -e '/paths.extend(SYSTEM_JUPYTER_PATH)/d' \
           -e '/paths.extend(SYSTEM_CONFIG_PATH)/d' \
             ./jupyter_core/paths.py
+        sed -i -E 's/(ENV_JUPYTER_PATH = )(\[.*\])/\1[]/g' ./jupyter_core/paths.py
+        sed -i -E 's/(ENV_CONFIG_PATH = )(\[.*\])/\1[]/g' ./jupyter_core/paths.py
       '';
     });
   }

--- a/overrides.nix
+++ b/overrides.nix
@@ -9,11 +9,18 @@ in
   // addNativeBuildInputs "jsonschema" [final.hatchling final.hatch-vcs]
   // addNativeBuildInputs "traitlets" [final.hatchling]
   // addNativeBuildInputs "terminado" [final.hatchling]
-  // addNativeBuildInputs "jupyter-client" [final.hatchling]
   // addNativeBuildInputs "jupyter-server" [final.hatchling]
   // addNativeBuildInputs "jupyterlab-server" [final.hatchling]
   // addNativeBuildInputs "ipykernel" [final.hatchling]
   // {
+    jupyter-client = prev.jupyter-client.overridePythonAttrs (old: {
+      nativeBuildInputs = (old.nativeBuildInputs or []) ++ [final.hatchling];
+      postPatch = ''
+        sed -i \
+          -e "/ensure_native_kernel = Bool(/!b;n;c\        False," \
+          jupyter_client/kernelspec.py
+      '';
+    });
     jupyter-core = prev.jupyter-core.overridePythonAttrs (old: {
       postPatch = ''
         # remove system paths from jupyter paths

--- a/overrides.nix
+++ b/overrides.nix
@@ -13,3 +13,13 @@ in
   // addNativeBuildInputs "jupyter-server" [final.hatchling]
   // addNativeBuildInputs "jupyterlab-server" [final.hatchling]
   // addNativeBuildInputs "ipykernel" [final.hatchling]
+  // {
+    jupyter-core = prev.jupyter-core.overridePythonAttrs (old: {
+      postPatch = ''
+        sed -i \
+          -e '/paths.extend(SYSTEM_JUPYTER_PATH)/d' \
+          -e '/paths.extend(SYSTEM_CONFIG_PATH)/d' \
+            ./jupyter_core/paths.py
+      '';
+    });
+  }

--- a/overrides.nix
+++ b/overrides.nix
@@ -16,6 +16,7 @@ in
     jupyter-client = prev.jupyter-client.overridePythonAttrs (old: {
       nativeBuildInputs = (old.nativeBuildInputs or []) ++ [final.hatchling];
       postPatch = ''
+        # default the native kernel to False so it does not appear in the env
         sed -i \
           -e "/ensure_native_kernel = Bool(/!b;n;c\        False," \
           jupyter_client/kernelspec.py


### PR DESCRIPTION
Closes #39. The jupyter runtime directory needs write access for ephemeral files that are cleared out after the jupyter server shuts down. The runtime directory will be set to `/home/<USER>/.local/share/jupyter/runtime` while data and config will remain in the nix store.